### PR TITLE
Hide ring when disabled

### DIFF
--- a/src/FocusRing.tsx
+++ b/src/FocusRing.tsx
@@ -77,6 +77,12 @@ export default function FocusRing(props: FocusRingComponentProps) {
     ringContext.invalidate();
   });
 
+  // If this ring no longer is enabled, hide it.
+  React.useEffect(() => {
+    if (!enabled) ringContext.hide();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled]);
+
   // If this ring was active, hide it when this component unmounts.
   React.useEffect(() => {
     return () => {


### PR DESCRIPTION
Hi there,

When the `enabled` prop in `<FocusRing enabled={isKeyboardMode} />` changes from `true` to `false`, the ring [remains visible](https://codesandbox.io/s/loving-galileo-ogu85?file=/src/index.tsx). However, this is not the case in the Discord app, so I'm not sure if I'm doing something wrong here. Regardless, this resolves the issue for me. Let me know if I should do something differently!

Thank you!
Kind regards,
Hampus Kraft.