### PR TITLE
Add optional themeOptions on FocusRingScope

### DIFF
--- a/src/FocusColorUtils.tsx
+++ b/src/FocusColorUtils.tsx
@@ -1,15 +1,16 @@
 import Color from "./util/Color";
 import mixColors from "./util/mixColors";
 
-import type { FocusRingAncestry } from "./FocusRingTypes";
+import type { FocusRingAncestry, ThemeOptions } from "./FocusRingTypes";
 
 enum ALLOWED_FOCUS_RING_COLORS {
   PRIMARY = "var(--focus-primary)",
   WHITE = "rgba(255,255,255,0.7)",
-  BLACK = "rgba(0, 0, 0, 0.85)",
+  LIGHT = "var(--focus-light, rgba(255,255,255,0.7))",
+  DARK = "var(--focus-dark, rgba(0, 0, 0, 0.85))",
 }
 
-export function getBestFocusColor(color?: Color) {
+export function getBestFocusColor(color?: Color, themeOptions?: ThemeOptions) {
   if (color == null) return ALLOWED_FOCUS_RING_COLORS.PRIMARY;
 
   const { saturation } = color.toHSL();
@@ -17,8 +18,13 @@ export function getBestFocusColor(color?: Color) {
   if (saturation <= 0.4) {
     return ALLOWED_FOCUS_RING_COLORS.PRIMARY;
   }
+  if (typeof themeOptions !== 'undefined') {
+    const defaultTreshold = 0.2;
+    const threshold = themeOptions.brightnessTreshold || defaultTreshold;
+    return brightness < threshold ? ALLOWED_FOCUS_RING_COLORS.LIGHT : ALLOWED_FOCUS_RING_COLORS.DARK;
+  }
 
-  return brightness < 200 ? ALLOWED_FOCUS_RING_COLORS.WHITE : ALLOWED_FOCUS_RING_COLORS.BLACK;
+  return ALLOWED_FOCUS_RING_COLORS.WHITE;
 }
 
 export function getBackgroundColorFromAncestry(ancestry: FocusRingAncestry): Color {

--- a/src/FocusRingContext.tsx
+++ b/src/FocusRingContext.tsx
@@ -8,6 +8,7 @@ import {
   FocusRingStyleProperties,
   FOCUS_RING_COLOR_CSS_PROPERTY,
   FOCUS_RING_RADIUS_CSS_PROPERTY,
+  ThemeOptions,
 } from "./FocusRingTypes";
 
 // This is a global singleton value because there should only ever be one focus
@@ -39,11 +40,16 @@ export class FocusRingContextManager {
   offset: Offset | number = 0;
   zIndex?: number;
   container: Element | null = null;
+  themeOptions?: ThemeOptions;
 
   invalidate: () => void = () => null;
 
   setContainer(element: Element | null) {
     this.container = element;
+  }
+
+  setThemeOptions(themeOptions?: ThemeOptions) {
+    this.themeOptions = themeOptions;
   }
 
   showElement(element: Element, opts: FocusRingShowOpts = {}) {
@@ -169,7 +175,7 @@ export class FocusRingContextManager {
       styles = {
         ...this.makePositionFromDOMRect(this.targetElement.getBoundingClientRect()),
         zIndex: this.zIndex ?? this.getNextZIndexForAncestry(this.targetAncestry),
-        [FOCUS_RING_COLOR_CSS_PROPERTY]: getBestFocusColor(backgroundColor),
+        [FOCUS_RING_COLOR_CSS_PROPERTY]: getBestFocusColor(backgroundColor, this.themeOptions),
         [FOCUS_RING_RADIUS_CSS_PROPERTY]: this.getBorderRadius(this.targetAncestry),
       };
     }

--- a/src/FocusRingScope.tsx
+++ b/src/FocusRingScope.tsx
@@ -2,18 +2,21 @@ import * as React from "react";
 import classNames from "classnames";
 
 import FocusRingContext, { FocusRingContextManager } from "./FocusRingContext";
+import { ThemeOptions } from "./FocusRingTypes";
 
 type FocusRingScopeProps = {
   containerRef: React.RefObject<Element>;
   children: React.ReactNode;
+  themeOptions?: ThemeOptions;
 };
 
 export default function FocusRingScope(props: FocusRingScopeProps) {
-  const { containerRef, children } = props;
+  const { containerRef, children, themeOptions } = props;
   const manager = React.useRef(new FocusRingContextManager());
 
   React.useEffect(() => {
     manager.current.setContainer(containerRef.current);
+    manager.current.setThemeOptions(themeOptions);
     // We do actually want this to run every time `current` changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [containerRef.current]);

--- a/src/FocusRingTypes.tsx
+++ b/src/FocusRingTypes.tsx
@@ -40,3 +40,7 @@ export type FocusRingStyleProperties = {
   [FOCUS_RING_COLOR_CSS_PROPERTY]?: string;
   [FOCUS_RING_RADIUS_CSS_PROPERTY]?: string;
 };
+
+export type ThemeOptions = {
+  brightnessTreshold?: number;
+};


### PR DESCRIPTION
Add light and dark css var and fix brightness calculation to allow these colors. 
Brightness is a value from 0 to 1 and by default set to 0.2.
The prop themeOptions is optional and if undefined, Focus ring will have the same behavior as before. Otherwise, It will use light & dark theme (if saturation > 0.4).
Moreover, saturation could be part of themeOptions but I chose not to touch it.

Example : 
```
<FocusRingScope containerRef={containerRef}>
```
No behavior change, it will still be primary or white ring

```
<FocusRingScope themeOptions={{ brightnessTreshold: 0.3 }} containerRef={containerRef}>
```
If the background brightness is 0.4, ring will be set to dark

```
<FocusRingScope themeOptions={{ brightnessTreshold: 0.3 }} containerRef={containerRef}>
```
If the background brightness is 0.2, ring will be set to light


Its an answer to this issue => https://github.com/discord/focus-rings/issues/8