### PR TITLE
Fix blog post link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A centralized system for displaying and stylizing focus indicators anywhere on a
 When working on creating [a complete keyboard navigation experience for Discord](https://support.discord.com/hc/en-us/articles/1500000056121), we ran into a number
 of problems with rendering clean and consistent focus rings and were unable to find any suitable
 native alternatives. After a lot of trial and error, we landed on this system as a way to meet all
-of our needs. You can read more about the process we went through in [this blog post](https://blog.discord.com/how-discord-implemented-app-wide-keyboard-navigation-abf073fd71de).
+of our needs. You can read more about the process we went through in [this blog post](https://discord.com/blog/how-discord-implemented-app-wide-keyboard-navigation).
 
 ## Installation
 


### PR DESCRIPTION
Y'all's blog post link is broken, and the redirect doesn't seem to work anymore.